### PR TITLE
fix NPM OIDC auth and GHPR provenance conflicts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,7 @@ jobs:
   publish_to_npm:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for Trusted Publishers (OIDC)
-      contents: read
+      id-token: write # Required for Trusted Publishers (OIDC) 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --provenance --access public
 
   publish_to_ghpr:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ jobs:
   publish_to_npm:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for Trusted Publishers (OIDC) 
+      id-token: write # Required for Trusted Publishers (OIDC)
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabez007/cryptotron-js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A TypeScript library for classical cryptography ciphers including Caesar, Vigenère, Substitution, and more.",
   "exports": "./src/index.ts",
   "tasks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jabez007/cryptotron.js",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jabez007/cryptotron.js",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@jabez007/cryptotron.js",
   "version": "0.2.2",
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabez007/cryptotron.js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.3 for both npm and Deno packages.
  * Updated publishing configuration to enable provenance generation and ensure packages are published with public access.
  * Removed a redundant provenance setting from the package manifest to keep configuration consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->