### PR TITLE
use actions v6 and clean up repository metadata for NPM OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabez007/cryptotron-js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A TypeScript library for classical cryptography ciphers including Caesar, Vigenère, Substitution, and more.",
   "exports": "./src/index.ts",
   "tasks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jabez007/cryptotron.js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jabez007/cryptotron.js",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabez007/cryptotron.js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jabez007/cryptotron.js"
+    "url": "git+https://github.com/jabez007/cryptotron.js.git"
   },
   "bugs": {
     "url": "https://github.com/jabez007/cryptotron.js/issues"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jabez007/cryptotron.js.git"
+    "url": "https://github.com/jabez007/cryptotron.js"
   },
   "bugs": {
     "url": "https://github.com/jabez007/cryptotron.js/issues"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package and manifest version to 0.2.4.
  * Updated CI/CD workflow to use the latest GitHub Actions and Node.js 24.x runtime for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->